### PR TITLE
Simple fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,11 @@
 ## Installation  
 1. Clone the repository:  
    ```
-   git clone https://github.com/username/lanmap.git  
-   cd lanmap
+   git clone https://github.com/JosephRedman/LanMap.git
+   cd LanMap
    ```
 
-2. Install dependencies:
-   ```
-   pip install -r requirements.txt
-   ```
-3. Run the application:
+2. Run the application:
    ```
    python Main.py
    ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-tkinter
-json


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change updates the repository URL and corrects the directory name for cloning the repository, and simplifies the installation instructions by removing the step to install dependencies. 

Changes in `README.md`:

* Updated repository URL to `https://github.com/JosephRedman/LanMap.git` and corrected the directory name to `LanMap`.
* Removed the step to install dependencies and simplified the instructions to directly run the application.

(copilot, im lazy to write)